### PR TITLE
Remove use of custom GeometryOps fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,12 +73,6 @@ WORKDIR "${APP_SRC_DIR}"
 # Copy project and manifest - includes Manifest-v1.11 etc
 COPY Project.toml Manifest*.toml ./
 
-# Add custom fork of GeometryOps
-# TODO: Remove once fix that resolves precompilation issues gets released
-#       (blocks system image generation)
-RUN julia --project=@app \
-    -e 'using Pkg; Pkg.add(url="https://github.com/ConnectedSystems/GeometryOps.jl", rev="main");'
-
 # Install the ReefGuideWorker source code and configure it as a development
 # package in the @app shared environment.
 # Should be v speedy if the .toml file is unchanged, because all the

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.5"
 manifest_format = "2.0"
-project_hash = "f28582dabfffb72b7502724bd57602c8444012ab"
+project_hash = "946898f13b3fef6abbcff3f1693804f72b5148d2"
 
 [[deps.AWS]]
 deps = ["Base64", "Compat", "Dates", "Downloads", "GitHub", "HTTP", "IniFile", "JSON", "MbedTLS", "Mocking", "OrderedCollections", "Random", "SHA", "Sockets", "URIs", "UUIDs", "XMLDict"]
@@ -805,11 +805,9 @@ version = "0.5.9"
 
 [[deps.GeometryOps]]
 deps = ["AbstractTrees", "AdaptivePredicates", "CoordinateTransformations", "DataAPI", "DelaunayTriangulation", "ExactPredicates", "Extents", "GeoFormatTypes", "GeoInterface", "GeometryOpsCore", "LinearAlgebra", "SortTileRecursiveTree", "StaticArrays", "Statistics", "Tables"]
-git-tree-sha1 = "10ed59ba219a58f3ab17bca99a16a38af649a3a8"
-repo-rev = "main"
-repo-url = "https://github.com/ConnectedSystems/GeometryOps.jl"
+git-tree-sha1 = "1b7fef8228b2fb471548d6a1e1b644056b536970"
 uuid = "3251bfac-6a57-4b6d-aa61-ac1fef2975ab"
-version = "0.1.25"
+version = "0.1.26"
 
     [deps.GeometryOps.extensions]
     GeometryOpsDataFramesExt = "DataFrames"

--- a/Project.toml
+++ b/Project.toml
@@ -20,14 +20,12 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ReefGuide = "cee0a5fb-9790-4c4c-b8b7-e40ecbebeb72"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
-[sources]
-GeometryOps = {rev = "main", url = "https://github.com/ConnectedSystems/GeometryOps.jl"}
-
 [compat]
 AWS = "1.92.0"
 AWSS3 = "0.11.2"
 DataFrames = "1.7.0"
 DotEnv = "1.0.0"
+GeometryOps = "0.1.26"
 JSON3 = "1.14.2"
 Logging = "1.11.0"
 Minio = "0.2.2"

--- a/src/job_worker/http_client.jl
+++ b/src/job_worker/http_client.jl
@@ -17,7 +17,7 @@ struct ApiError <: Exception
 end
 
 """
-Represents JWT payload structure 
+Represents JWT payload structure
 
 (This is what's in the token)
 """
@@ -80,7 +80,7 @@ function get_valid_token(client::AuthApiClient)::Union{String,Nothing}
 
     exp_time = decoded_token["exp"]
 
-    # Get current unix timestamp 
+    # Get current unix timestamp
     current_unix = floor(Int64, Dates.datetime2unix(Dates.now(Dates.UTC)))
 
     # convert to ms
@@ -228,7 +228,6 @@ function HTTPPost(
         return JSON3.read(response_content)
     end
 end
-
 
 """
 Post using string json data

--- a/src/utility/regions_criteria_setup.jl
+++ b/src/utility/regions_criteria_setup.jl
@@ -93,7 +93,7 @@ function initialise_data_with_cache(;
         end
 
         # Try disk cache second (faster than full reload)
-        disk_data = check_existing_regional_data_from_disk(cache_path=cache_path)
+        disk_data = check_existing_regional_data_from_disk(; cache_path=cache_path)
         if !isnothing(disk_data)
             REGIONAL_DATA = disk_data
             return nothing
@@ -114,7 +114,7 @@ function initialise_data_with_cache(;
     try
         # Ensure cache directory exists
         mkpath(cache_path)
-        
+
         serialize(
             joinpath(cache_path, REGIONAL_DATA_CACHE_FILENAME),
             regional_data
@@ -144,7 +144,7 @@ function get_regional_data(; data_path::String, cache_path::String)::ReefGuide.R
     @debug "Getting regional data with automatic cache management" data_path cache_path
 
     # Ensure data is loaded (with caching)
-    initialise_data_with_cache(data_path=data_path, cache_path=cache_path)
+    initialise_data_with_cache(; data_path=data_path, cache_path=cache_path)
 
     # Return cached data
     return REGIONAL_DATA


### PR DESCRIPTION
Remove dependency on custom fork of GeometryOps.jl as a new version was released with the submitted fix:

https://github.com/JuliaGeo/GeometryOps.jl/releases/tag/v0.1.26
